### PR TITLE
Support running refmt.

### DIFF
--- a/OCamlTest/OCamlTest.xcodeproj/project.pbxproj
+++ b/OCamlTest/OCamlTest.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C929BE031E36708700A0CC2C /* libGobi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C929BE021E36708700A0CC2C /* libGobi.a */; };
+		278727F21E3805CF004B754D /* libGobi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 278727F11E3805CF004B754D /* libGobi.a */; };
 		C99F606A1E34FE8F0064B563 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C99F60691E34FE8F0064B563 /* main.m */; };
 		C99F606D1E34FE8F0064B563 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C99F606C1E34FE8F0064B563 /* AppDelegate.m */; };
 		C99F60701E34FE8F0064B563 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C99F606F1E34FE8F0064B563 /* ViewController.m */; };
@@ -28,7 +28,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		C929BE021E36708700A0CC2C /* libGobi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libGobi.a; path = ../../build/libGobi.a; sourceTree = "<group>"; };
+		278727F11E3805CF004B754D /* libGobi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libGobi.a; path = ../_build/libGobi.a; sourceTree = "<group>"; };
 		C99F60651E34FE8F0064B563 /* OCamlTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OCamlTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C99F60691E34FE8F0064B563 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		C99F606B1E34FE8F0064B563 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -49,7 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C929BE031E36708700A0CC2C /* libGobi.a in Frameworks */,
+				278727F21E3805CF004B754D /* libGobi.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,12 +63,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		278727F01E3805CF004B754D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				278727F11E3805CF004B754D /* libGobi.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		C99F605C1E34FE8E0064B563 = {
 			isa = PBXGroup;
 			children = (
 				C99F60671E34FE8F0064B563 /* OCamlTest */,
 				C99F60811E34FE8F0064B563 /* OCamlTestTests */,
 				C99F60661E34FE8F0064B563 /* Products */,
+				278727F01E3805CF004B754D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -92,7 +101,6 @@
 				C99F60741E34FE8F0064B563 /* Assets.xcassets */,
 				C99F60761E34FE8F0064B563 /* LaunchScreen.storyboard */,
 				C99F60791E34FE8F0064B563 /* Info.plist */,
-				C929BE021E36708700A0CC2C /* libGobi.a */,
 				C99F60681E34FE8F0064B563 /* Supporting Files */,
 			);
 			path = OCamlTest;
@@ -359,15 +367,18 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../bin/ocaml-iPhoneOS-64/release/lib/ocaml/caml\"";
 				INFOPLIST_FILE = OCamlTest/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_NO_PIE = NO;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/OCamlTest",
-					"\"$(SRCROOT)/../build\"",
+					"\"$(SRCROOT)/../_build\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.wokalski.OCamlTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SYMROOT = _build;
 			};
 			name = Debug;
 		};
@@ -379,15 +390,18 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../bin/ocaml-iPhoneOS-64/release/lib/ocaml/caml\"";
 				INFOPLIST_FILE = OCamlTest/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_NO_PIE = NO;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/OCamlTest",
-					"\"$(SRCROOT)/../build\"",
+					"\"$(SRCROOT)/../_build\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.wokalski.OCamlTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SYMROOT = _build;
 			};
 			name = Release;
 		};

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ contained in it.
 
 You can verify that it works by double clicking the project and clicking run.
 
+#Using with [Reason](https://github.com/facebook/reason)
+Gobi works with [Reason](https://github.com/facebook/reason) by assuming `refmt` is available globally. The simplest way to avoid installing Reason globally, for this project, is to use npm (as explained on Reason's README) and then run `PATH=$PATH:path/to/reason/_build/ocamlfind/bin/ ./gobi hello.re`.
+
 #Issues
 
 This project is just Proof of Concept. All ideas are welcome so please create

--- a/gobi
+++ b/gobi
@@ -39,7 +39,6 @@ do
 		ARCH=${!ARCH}
 		$OCAML_COMPILER/bin/ocamlopt $SOURCES -output-obj -o ${PRODUCT}.o
 		PRODUCT=$(pwd)/_build/tmp/$OUTPUT
-    cp ${OCAML_ASMRUN_LIB}.a ${PRODUCT}.a
 		cp ${OCAML_ASMRUN_LIB}.a ${PRODUCT}.a
 		ar -r ${PRODUCT}.a ${PRODUCT}.o
 		PRODUCTS="$PRODUCTS ${PRODUCT}.a" 

--- a/gobi
+++ b/gobi
@@ -26,7 +26,6 @@ iPhoneOS32=armv7
 iPhoneSimulator64=x86_64
 iPhoneSimulator32=i386
 
-for BITS in 32 64 
 for BITS in 32 64
 do
 	for PLATFORM in ${PLATFORMS[@]}

--- a/gobi
+++ b/gobi
@@ -40,6 +40,7 @@ do
 		$OCAML_COMPILER/bin/ocamlopt $SOURCES -output-obj -o ${PRODUCT}.o
 		PRODUCT=$(pwd)/_build/tmp/$OUTPUT
     cp ${OCAML_ASMRUN_LIB}.a ${PRODUCT}.a
+		cp ${OCAML_ASMRUN_LIB}.a ${PRODUCT}.a
 		ar -r ${PRODUCT}.a ${PRODUCT}.o
 		PRODUCTS="$PRODUCTS ${PRODUCT}.a" 
 	done

--- a/gobi
+++ b/gobi
@@ -4,14 +4,10 @@ PLATFORMS=(iPhoneSimulator iPhoneOS)
 
 SOURCES=""
 PRODUCTS=""
-mkdir -p build/tmp
 mkdir -p _build/tmp
 
 for FILE in "$@"
 do
-	SOURCE=$(pwd)/build/tmp/$FILE
-	cp $FILE $(pwd)/build/tmp
-	SOURCES="$SOURCES $SOURCE"
   if [ ${FILE: -3} == ".re" ] ; then
     IFS='.' read -ra BASENAME <<< "$FILE"    #Convert string to array
     # This will break if the file name has more than one dot
@@ -42,9 +38,9 @@ do
 		OCAML_ASMRUN_LIB=$OCAML_COMPILER/lib/ocaml/libasmrun
 		ARCH=$PLATFORM$BITS
 		ARCH=${!ARCH}
-		PRODUCT=$(pwd)/build/tmp/$OUTPUT
 		$OCAML_COMPILER/bin/ocamlopt $SOURCES -output-obj -o ${PRODUCT}.o
-		cp $OCAML_COMPILER/lib/ocaml/libasmrun.a ${PRODUCT}.a
+		PRODUCT=$(pwd)/_build/tmp/$OUTPUT
+    cp ${OCAML_ASMRUN_LIB}.a ${PRODUCT}.a
 		ar -r ${PRODUCT}.a ${PRODUCT}.o
 		PRODUCTS="$PRODUCTS ${PRODUCT}.a" 
 	done

--- a/gobi
+++ b/gobi
@@ -5,12 +5,24 @@ PLATFORMS=(iPhoneSimulator iPhoneOS)
 SOURCES=""
 PRODUCTS=""
 mkdir -p build/tmp
+mkdir -p _build/tmp
 
 for FILE in "$@"
 do
 	SOURCE=$(pwd)/build/tmp/$FILE
 	cp $FILE $(pwd)/build/tmp
 	SOURCES="$SOURCES $SOURCE"
+  if [ ${FILE: -3} == ".re" ] ; then
+    IFS='.' read -ra BASENAME <<< "$FILE"    #Convert string to array
+    # This will break if the file name has more than one dot
+    refmt --parse re --print ml ${BASENAME[0]}.re > $(pwd)/_build/tmp/${BASENAME[0]}.ml
+    SOURCE=$(pwd)/_build/tmp/${BASENAME[0]}.ml
+    SOURCES="$SOURCES $SOURCE"
+  else
+    SOURCE=$(pwd)/_build/tmp/$FILE
+    cp $FILE $(pwd)/_build/tmp
+    SOURCES="$SOURCES $SOURCE"
+  fi
 done
 
 iPhoneOS64=arm64
@@ -19,6 +31,7 @@ iPhoneSimulator64=x86_64
 iPhoneSimulator32=i386
 
 for BITS in 32 64 
+for BITS in 32 64
 do
 	for PLATFORM in ${PLATFORMS[@]}
 	do


### PR DESCRIPTION
This isn't the best way to do it as we're generating an ml file so any
syntax error message will show ml code etc... But I haven't figured out
how to fix the issue that passing `-pp refmt` to the ios ocaml compiler
doesn't work. It says ">> Fatal error: OCaml and preprocessor have
incompatible versions"

Also switched to using `_build` instead of `build` mostly because all of the Reason tooling uses `_build` :)